### PR TITLE
fix caching problem in development mode where classes are reloaded

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -19,9 +19,12 @@
 
 require 'redmine'
 require 'dispatcher'
-
+require 'redmine_ical/patch_redmine_classes'
+  
 Dispatcher.to_prepare do
-  require 'redmine_ical/patch_redmine_classes'
+  CalendarsController.send(:include, ::Plugin::Ical::CalendarsController)
+	Issue.send(:include, ::Plugin::Ical::Issue)
+	Version.send(:include, ::Plugin::Ical::Version)
 end
 
 require_dependency 'redmine_ical/view_hooks'

--- a/lib/redmine_ical/patch_redmine_classes.rb
+++ b/lib/redmine_ical/patch_redmine_classes.rb
@@ -141,7 +141,3 @@ module Plugin
     end
   end
 end
-
-CalendarsController.send(:include, ::Plugin::Ical::CalendarsController)
-Issue.send(:include, ::Plugin::Ical::Issue)
-Version.send(:include, ::Plugin::Ical::Version)


### PR DESCRIPTION
The Dispatcher.prepare block will run every time in development mode, however, the require will only load/execute the file once. Thus, we need to put the send commands directly in the Dispatcher.prepare block.
